### PR TITLE
Small Fixes for Security & Check Mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
     line: "[{{ postfix_aws_ses_host }}]:{{ postfix_aws_ses_port }} {{ postfix_aws_ses_username }}:{{ postfix_aws_ses_password }}"
     state: present
   register: postfix_aws_credentials_res
+  no_log: yes
   notify: Restart Postfix
 
 - name: Create a hashmap database file with SMTP credentials

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,7 @@
     owner: root
     group: root
     mode: 0600
+  ignore_errors: "{{ ansible_check_mode }}"
   with_items:
     - /etc/postfix/sasl_passwd.db
     - /etc/postfix/sasl_passwd


### PR DESCRIPTION
* Do not, by default, allow logging of credentials
* Attempt to ensure a first run with `--check` mode does not unexpectedly fail